### PR TITLE
Feature/original url tooltip

### DIFF
--- a/assets/tooltip.css
+++ b/assets/tooltip.css
@@ -2,43 +2,30 @@
     position: relative;
 }
 
-/* The triangle tip of the tooltip */
-[data-url-tooltip]::before {
-    content: "";
-    position: absolute;
-    top: -6px;
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 4px 6px 0 6px;
-    border-style: solid;
-    border-color: rgba(0, 0, 0, 0.7) transparent transparent transparent;
-    z-index: 100;
-}
-
 /* The bubble of the tooltip */
 [data-url-tooltip]::after {
     content: attr(data-url-tooltip);
-    font-size: 14px;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 16px;
     line-height: 1.2;
     color: #fff;
     text-align: center;
-    position: absolute;
+    position: fixed;
     left: 50%;
-    top: -6px;
-    transform: translateX(-50%) translateY(-100%);
-    min-width: 80px;
-    padding: 4px;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    min-width: 200px;
+    padding: 12px;
     background: rgba(0, 0, 0, 0.7);
     border-radius: 5px;
     pointer-events: none;
+    transition: all 0.5s;
 }
 
 [data-url-tooltip]::before, [data-url-tooltip]::after {
     opacity: 0;
-    transition: all 0.5s;
 }
 
 [data-url-tooltip]:hover::before, [data-url-tooltip]:hover::after {
     opacity: 1;
-    transition: all 0.5s;
 }

--- a/assets/tooltip.css
+++ b/assets/tooltip.css
@@ -1,0 +1,44 @@
+[data-url-tooltip]{
+    position: relative;
+}
+
+/* The triangle tip of the tooltip */
+[data-url-tooltip]::before {
+    content: "";
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 4px 6px 0 6px;
+    border-style: solid;
+    border-color: rgba(0, 0, 0, 0.7) transparent transparent transparent;
+    z-index: 100;
+}
+
+/* The bubble of the tooltip */
+[data-url-tooltip]::after {
+    content: attr(data-url-tooltip);
+    font-size: 14px;
+    line-height: 1.2;
+    color: #fff;
+    text-align: center;
+    position: absolute;
+    left: 50%;
+    top: -6px;
+    transform: translateX(-50%) translateY(-100%);
+    min-width: 80px;
+    padding: 4px;
+    background: rgba(0, 0, 0, 0.7);
+    border-radius: 5px;
+    pointer-events: none;
+}
+
+[data-url-tooltip]::before, [data-url-tooltip]::after {
+    opacity: 0;
+    transition: all 0.5s;
+}
+
+[data-url-tooltip]:hover::before, [data-url-tooltip]:hover::after {
+    opacity: 1;
+    transition: all 0.5s;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,11 @@
                 "/supported-domains.js",
                 "/services/url-parser.js",
                 "/services/request-url.js",
+                "/services/tooltip-service.js",
                 "/content_scripts/main-content-script.js"
+            ],
+            "css": [
+                "assets/tooltip.css"
             ]
         }
     ]

--- a/services/tooltip-service.js
+++ b/services/tooltip-service.js
@@ -1,0 +1,18 @@
+var anchors = document.getElementsByTagName('a');
+
+setUrlAttributeForAnchors();
+
+/**
+ * Get original URL of anchors and set the result as its attribute
+ *
+ */
+function setUrlAttributeForAnchors() {
+    for (let i = 0; i < anchors.length; i++) {
+        const anchor = anchors[i];
+        if (supportedDomains.indexOf(getHostName(anchor.href)) > -1) {
+            requestUrl(anchor.href).then(originalURL => {
+                anchor.setAttribute('data-url-tooltip', originalURL);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Find all anchor elements in the page, if the domain is in supported list, then request the original URL and set the result to attribute `data-url-tooltip` of respective anchor element. 
Whenever user hovers an anchor element, a tooltip displays this value will appear in the center of the viewport.