### PR TITLE
feat(SupportedDomains): Add more supported domains

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <style>
         body {
-            background: #aaaaaa
+            background: lightblue;
         }
     </style>
 </head>
@@ -13,10 +13,31 @@
 <body>
     <h1>Demo site</h1>
     <p>
-        <a href="http://goo.gl/vGWaZV">goo.gl => https://github.com/huyld/url-revealer</a>
+        <a href="http://7.ly/tWxp">7.ly => Google Maps - Mua Cave</a>
     </p>
     <p>
-        <a href="http://bit.ly/2xxeDVD">bit.ly => https://github.com/huyld/url-revealer</a>
+        <a href="http://flic.kr/p/26CgBgH">flic.kr => Flickr</a>
+    </p>
+    <p>
+        <a href="https://git.io/fNYfv">git.io => Github - mdn/webextensions-examples</a>
+    </p>
+    <p>
+        <a href="http://goo.gl/vGWaZV">goo.gl => Github - URL Revealer</a>
+    </p>
+    <p>
+        <a href="https://is.gd/kVx6hw">is.gd => Google Maps - Mua Cave</a>
+    </p>
+    <p>
+        <a href="http://tiny.cc/428cvy">tiny.cc => Google Maps - Mua Cave</a>
+    </p>
+    <p>
+        <a href="https://tinyurl.com/KindleWireless">tinyurl.com => Amazon</a>
+    </p>
+    <p>
+        <a href="http://tny.im/eQ7">tny.im => Google Maps - Mua Cave</a>
+    </p>
+    <p>
+        <a href="http://y2u.be/vyUnzfMh-zA">y2u.be => Youtube - The journey to Pluto, the farthest world ever explored - Alan Stern</a>
     </p>
 </body>
 

--- a/services/request-url.js
+++ b/services/request-url.js
@@ -10,7 +10,7 @@ function requestUrl(sourceUrl) {
         var xhr = new XMLHttpRequest();
         xhr.onreadystatechange = onStateChangeCallback.bind(this, resolve, reject, xhr);
         switch (hostname) {
-            case TINYURL:
+            case TINYURL_COM:
                 // tinyurl.com doesn't allow HEAD method
                 xhr.open('GET', sourceUrl, true);
                 break;

--- a/supported-domains.js
+++ b/supported-domains.js
@@ -1,9 +1,21 @@
-const TINYURL = 'tinyurl.com';
-const BITLY = 'bit.ly';
-const GOOGL = 'goo.gl';
+const _7ly = '7.ly';
+const FLIC_KR = 'flic.kr';
+const GOO_GL = 'goo.gl';
+const GIT_IO = 'git.io';
+const IS_GD = 'is.gd';
+const TINY_CC = 'tiny.cc';
+const TINYURL_COM = 'tinyurl.com';
+const TNY_IM = 'tny.im';
+const Y2U_BE = 'y2u.be';
 
 var supportedDomains = [
-    BITLY,
-    GOOGL,
-    TINYURL
+    _7ly,
+    FLIC_KR,
+    GOO_GL,
+    GIT_IO,
+    IS_GD,
+    TINY_CC,
+    TINYURL_COM,
+    TNY_IM,
+    Y2U_BE
 ];


### PR DESCRIPTION
Add more supported domains:
- 7.ly
- flic.kr
- git.io
- is.gd
- tiny.cc
- tny.im
- y2u.be

Update demo page.