### PR TITLE
feat(CacheService): use local storage to store URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,7 @@
             "js": [
                 "/supported-domains.js",
                 "/services/url-parser.js",
+                "/services/cache-service.js",
                 "/services/request-url.js",
                 "/services/tooltip-service.js",
                 "/content_scripts/main-content-script.js"

--- a/services/cache-service.js
+++ b/services/cache-service.js
@@ -1,0 +1,53 @@
+/**
+ * Save short URL, original URL and current time to local storage
+ * {
+ *      <shortenedUrl>: {
+ *          originalUrl: string,
+ *          cachedDate: Date
+ *      }
+ * }
+ *
+ * @param {*} shortUrl
+ * @param {*} originalUrl
+ */
+function updateUrl(shortUrl, originalUrl) {
+    let contentToStore = {};
+    contentToStore[shortUrl] = {
+        originalUrl: originalUrl,
+        cachedDate: Date.now()
+    };
+    browser.storage.local.set(contentToStore);
+}
+
+/**
+ * Get information of short URL from local storage
+ *
+ * @param {*} shortUrl
+ * @returns
+ */
+function getCachedUrl(shortUrl) {
+    return browser.storage.local.get(shortUrl);
+}
+
+/**
+ * Check if cached data is valid or not
+ *
+ * @param {*} data
+ * @returns
+ */
+function isCacheDataValid(data) {
+    // Check if cached data is an empty object
+    if (Object.keys(data).length === 0 && data.constructor === Object) {
+        return false;
+    }
+
+    // Check if cached data is too old (more than 30 days)
+    if (
+        !!data[Object.keys(data)].cachedDate &&
+        new Date() - data[Object.keys(data)].cachedDate > 1000 * 3600 * 24 * 30
+    ) {
+        return false;
+    }
+
+    return true;
+}

--- a/services/tooltip-service.js
+++ b/services/tooltip-service.js
@@ -3,15 +3,28 @@ var anchors = document.getElementsByTagName('a');
 setUrlAttributeForAnchors();
 
 /**
- * Get original URL of anchors and set the result as its attribute
+ * Get original URL of anchors and set the result as its attribute.
+ * Use cached data if available.
  *
  */
 function setUrlAttributeForAnchors() {
     for (let i = 0; i < anchors.length; i++) {
         const anchor = anchors[i];
         if (supportedDomains.indexOf(getHostName(anchor.href)) > -1) {
-            requestUrl(anchor.href).then(originalURL => {
-                anchor.setAttribute('data-url-tooltip', originalURL);
+            getCachedUrl(anchor.href).then(storedInfo => {
+                // Check if the URL is stored in cache
+                if (isCacheDataValid(storedInfo)) {
+                    anchor.setAttribute(
+                        'data-url-tooltip',
+                        storedInfo[anchor.href].originalUrl
+                    );
+                } else {
+                    // Make new request for original URL if it's not in cache or too old
+                    requestUrl(anchor.href).then(originalURL => {
+                        anchor.setAttribute('data-url-tooltip', originalURL);
+                        updateUrl(anchor.href, originalURL);
+                    });
+                }
             });
         }
     }


### PR DESCRIPTION
New feature: cache service
- Store new shortened URL, its original URL and time of caching to local storage.
- Update URL in local storage if it's too told