### PR TITLE
fix(tooltip): other anchors overlay tooltip.

### DIFF
--- a/assets/tooltip.css
+++ b/assets/tooltip.css
@@ -1,7 +1,3 @@
-[data-url-tooltip]{
-    position: relative;
-}
-
 /* The bubble of the tooltip */
 [data-url-tooltip]::after {
     content: attr(data-url-tooltip);
@@ -22,10 +18,10 @@
     transition: all 0.5s;
 }
 
-[data-url-tooltip]::before, [data-url-tooltip]::after {
+[data-url-tooltip]::after {
     opacity: 0;
 }
 
-[data-url-tooltip]:hover::before, [data-url-tooltip]:hover::after {
+[data-url-tooltip]:hover::after {
     opacity: 1;
 }


### PR DESCRIPTION
- Fix display error: other anchors overlay tooltip.
![image](https://user-images.githubusercontent.com/3625371/45262999-98913480-b44b-11e8-869a-f7fdba10bc64.png)

- Remove unnecessary style for anchor tags