### PR TITLE
Feature/add more supported domains 20180915

### DIFF
--- a/background-scripts/supported-domains.js
+++ b/background-scripts/supported-domains.js
@@ -1,52 +1,74 @@
+const _2TU_US = '2tu.us';
 const _7ly = '7.ly';
 const ALTURL_COM = 'alturl.com';
 const B_LINK = 'b.link';
 const BIT_LY = 'bit.ly';
+const BUDURL_COM = 'budurl.com';
 const CHILP_IT = 'chilp.it';
+const DOIOP_COM = 'doiop.com';
 const EXAMPLES_NEWS = 'examples.news';
 const EXAMPLES_SOCIAL = 'examples.social';
 const INFORMATION_CODES = 'information.codes';
+const FAT_LY = 'fat.ly';
+const FF_IM = 'ff.im';
 const FLIC_KR = 'flic.kr';
 const GOO_GL = 'goo.gl';
 const GIT_IO = 'git.io';
 const IS_GD = 'is.gd';
+const KORTA_NU = 'korta.nu';
 const MERKY_DE = 'merky.de';
+const MIGRE_ME = 'migre.me';
+const OW_LY = 'ow.ly';
+const P_LY = 'p.ly';
 const SLNK_ME = 'slnk.me';
 const TCRN_CH = 'tcrn.ch';
 const TO_LY = 'to.ly';
+const TIGHTURL_COM = 'tighturl.com';
 const TINY_CC = 'tiny.cc';
 const TINYURL_COM = 'tinyurl.com';
 const TNY_IM = 'tny.im';
 const U_NU = 'u.nu';
 const URL_IE = 'url.ie';
 const URLCUT_COM = 'urlcut.com';
+const XRL_US = 'xrl.us';
 const Y2U_BE = 'y2u.be';
 const YATUC_COM = 'yatuc.com';
 const YEP_IT = 'yep.it';
 
 var supportedDomains = [
+    _2TU_US,
     _7ly,
     ALTURL_COM,
     B_LINK,
     BIT_LY,
+    BUDURL_COM,
     CHILP_IT,
+    DOIOP_COM,
     EXAMPLES_NEWS,
     EXAMPLES_SOCIAL,
+    FAT_LY,
+    FF_IM,
     FLIC_KR,
     GOO_GL,
     GIT_IO,
     IS_GD,
+    KORTA_NU,
     INFORMATION_CODES,
     MERKY_DE,
+    MIGRE_ME,
+    OW_LY,
+    P_LY,
     SLNK_ME,
     TCRN_CH,
     TO_LY,
+    TIGHTURL_COM,
     TINY_CC,
     TINYURL_COM,
     TNY_IM,
     U_NU,
     URL_IE,
     URLCUT_COM,
+    XRL_US,
     Y2U_BE,
     YATUC_COM,
     YEP_IT

--- a/background-scripts/supported-domains.js
+++ b/background-scripts/supported-domains.js
@@ -2,6 +2,7 @@ const _7ly = '7.ly';
 const ALTURL_COM = 'alturl.com';
 const B_LINK = 'b.link';
 const BIT_LY = 'bit.ly';
+const CHILP_IT = 'chilp.it';
 const EXAMPLES_NEWS = 'examples.news';
 const EXAMPLES_SOCIAL = 'examples.social';
 const INFORMATION_CODES = 'information.codes';
@@ -9,16 +10,26 @@ const FLIC_KR = 'flic.kr';
 const GOO_GL = 'goo.gl';
 const GIT_IO = 'git.io';
 const IS_GD = 'is.gd';
+const MERKY_DE = 'merky.de';
+const SLNK_ME = 'slnk.me';
+const TCRN_CH = 'tcrn.ch';
+const TO_LY = 'to.ly';
 const TINY_CC = 'tiny.cc';
 const TINYURL_COM = 'tinyurl.com';
 const TNY_IM = 'tny.im';
+const U_NU = 'u.nu';
+const URL_IE = 'url.ie';
+const URLCUT_COM = 'urlcut.com';
 const Y2U_BE = 'y2u.be';
+const YATUC_COM = 'yatuc.com';
+const YEP_IT = 'yep.it';
 
 var supportedDomains = [
     _7ly,
     ALTURL_COM,
     B_LINK,
     BIT_LY,
+    CHILP_IT,
     EXAMPLES_NEWS,
     EXAMPLES_SOCIAL,
     FLIC_KR,
@@ -26,8 +37,17 @@ var supportedDomains = [
     GIT_IO,
     IS_GD,
     INFORMATION_CODES,
+    MERKY_DE,
+    SLNK_ME,
+    TCRN_CH,
+    TO_LY,
     TINY_CC,
     TINYURL_COM,
     TNY_IM,
-    Y2U_BE
+    U_NU,
+    URL_IE,
+    URLCUT_COM,
+    Y2U_BE,
+    YATUC_COM,
+    YEP_IT
 ];

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -10,12 +10,37 @@
         a {
             text-decoration: none;
         }
+        .disclaimer {
+            padding: 10px 30px;
+            margin: auto 30px 40px;
+            background-color: lightgray;
+            font-family: Arial, sans-serif;
+        }
+        .disclaimer > h2 {
+            color: darkred;
+        }
+        .disclaimer > p:first-of-type {
+            font-weight: bold;
+            font-size: 20px;
+        }
+        .disclaimer > p:last-of-type {
+            font-size: 14px;
+        }
     </style>
 </head>
 
 <body>
     <h1>Demo page</h1>
-    <h3>Shorten URLs from supported domains</h3>
+    <section class="disclaimer">
+        <h2>Disclaimer</h2>
+        <p>
+            The author of this extension is not responsible for the content of the below URLs. The author does not involve in any promotional, propagative activities of these URLs. These URLs are here for the demonstration purpose of the extension only.
+        </p>
+        <p>
+            <i>Some URL shortenning services don't accept new URLs anymore so I'm unable to shorten new URL using those services. I have to use shortened URLs created by others. Although I try to keep the sample URLs as neutral as posible, some URLs content may appear as advertisement or promotion to some people.</i>
+        </p>
+    </section>
+    <h3>Shortened URLs from supported domains</h3>
     <ul>
         <li><a href="http://2tu.us/1ua7">2tu.us => offensive-security.com - Penetration Testing...</a></li>
         <li><a href="http://7.ly/tWxp">7.ly => Google Maps - Mua Cave</a></li>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -40,8 +40,8 @@
         <li><a href="http://ow.ly/nLNZ30h8PHp">ow.ly => CNN - 'Gods in Color' returns antiquities to their original, colorful grandeur</a></li>
         <li><a href="http://p.ly/1me3v">p.ly => CBC Radio - Podcast</a></li>
         <li><a href="https://slnk.me/ygQtml-Xsog">Youtube - Feel it in my bones => https://www.youtube.com/watch?v=ygQtml-Xsog)</a></li>
-        <li><a href="https://to.ly/1v4Si">Github - URL Revealer</a></li>
         <li><a href="https://tcrn.ch/2LN5kDX">Techcrunch - How Instagram’s algorithm works</a></li>
+        <li><a href="https://to.ly/1v4Si">Github - URL Revealer</a></li>
         <li><a href="http://tighturl.com/59ln">tighturl.com => Nature.com - A network-based gene-weighting approach for pathway analysis</a></li>
         <li><a href="http://tiny.cc/428cvy">tiny.cc => Google Maps - Mua Cave</a></li>
         <li><a href="https://tinyurl.com/KindleWireless">tinyurl.com => Amazon</a></li>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -20,6 +20,8 @@
         <li><a href="http://7.ly/tWxp">7.ly => Google Maps - Mua Cave</a></li>
         <li><a href="http://alturl.com/a4kcn">alturl.com => Google Maps - Mua Cave</a></li>
         <li><a href="http://b.link/examples79">b.link => Github - mdn/webextensions-examples</a></li>
+        <li><a href="http://bit.ly/2xxeDVD">bit.ly => Github - URL Revealer</a></li>
+        <li><a href="http://chilp.it/057752b">chilp.it => Github - URL Revealer</a></li>
         <li><a href="http://examples.news/github8">examples.news => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://examples.social/github4">examples.social => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://flic.kr/p/26CgBgH">flic.kr => Flickr</a></li>
@@ -27,10 +29,19 @@
         <li><a href="http://goo.gl/vGWaZV">goo.gl => Github - URL Revealer</a></li>
         <li><a href="http://information.codes/example4">information.codes => Github - mdn/webextensions-examples</a></li>
         <li><a href="https://is.gd/kVx6hw">is.gd => Google Maps - Mua Cave</a></li>
+        <li><a href="http://merky.de/h112f7">merky.de => Github - URL Revealer</a></li>
+        <li><a href="https://slnk.me/ygQtml-Xsog">Youtube - Feel it in my bones => https://www.youtube.com/watch?v=ygQtml-Xsog)</a></li>
+        <li><a href="https://to.ly/1v4Si">Github - URL Revealer</a></li>
+        <li><a href="https://tcrn.ch/2LN5kDX">Techcrunch - How Instagram’s algorithm works</a></li>
         <li><a href="http://tiny.cc/428cvy">tiny.cc => Google Maps - Mua Cave</a></li>
         <li><a href="https://tinyurl.com/KindleWireless">tinyurl.com => Amazon</a></li>
         <li><a href="http://tny.im/eQ7">tny.im => Google Maps - Mua Cave</a></li>
+        <li><a href="https://u.nu/dqt8">u.nu => Github - mdn/webextensions-examples</a></li>
+        <li><a href="http://url.ie/12v3z">u.nu => Github - mdn/webextensions-examples</a></li>
+        <li><a href="https://urlcut.com/1rrko">urlcut.com => dailymail.co.uk - Alert over energy drinks...</a></li>
         <li><a href="http://y2u.be/vyUnzfMh-zA">y2u.be => Youtube - The journey to Pluto, the farthest world ever explored - Alan Stern</a></li>
+        <li><a href="http://yatuc.com/yp">yatuc.com => ghacks.net - 5 Best Freeware Games of 2005</a></li>
+        <li><a href="http://yep.it/nhpuoh">yep.it => Github - mdn/webextensions-examples</a></li>
     </ul>
 </body>
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -17,28 +17,39 @@
     <h1>Demo page</h1>
     <h3>Shorten URLs from supported domains</h3>
     <ul>
+        <li><a href="http://2tu.us/1ua7">2tu.us => offensive-security.com - Penetration Testing...</a></li>
         <li><a href="http://7.ly/tWxp">7.ly => Google Maps - Mua Cave</a></li>
         <li><a href="http://alturl.com/a4kcn">alturl.com => Google Maps - Mua Cave</a></li>
         <li><a href="http://b.link/examples79">b.link => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://bit.ly/2xxeDVD">bit.ly => Github - URL Revealer</a></li>
+        <li><a href="http://budurl.com/np4u">budurl.com => Flickr - Atlanta Skyline by Mark Chandler</a></li>
         <li><a href="http://chilp.it/057752b">chilp.it => Github - URL Revealer</a></li>
+        <li><a href="https://doiop.com/jjkwdq">doiop.com => Amazon - The Greatest Baseball Stories Ever Told...</a></li>
         <li><a href="http://examples.news/github8">examples.news => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://examples.social/github4">examples.social => Github - mdn/webextensions-examples</a></li>
+        <li><a href="http://fat.ly/2Ohky">fat.ly => denverite.com - Minimum progress for students with...</a></li>
+        <li><a href="http://ff.im/plfSc">ff.im => Facebook - Portadown Liverpool Football Supporters Club</a></li>
         <li><a href="http://flic.kr/p/26CgBgH">flic.kr => Flickr</a></li>
         <li><a href="https://git.io/fNYfv">git.io => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://goo.gl/vGWaZV">goo.gl => Github - URL Revealer</a></li>
         <li><a href="http://information.codes/example4">information.codes => Github - mdn/webextensions-examples</a></li>
         <li><a href="https://is.gd/kVx6hw">is.gd => Google Maps - Mua Cave</a></li>
+        <li><a href="http://korta.nu/nsh">korta.nu => strikingly.com - Lighting Shop In Singapore</a></li>
         <li><a href="http://merky.de/h112f7">merky.de => Github - URL Revealer</a></li>
+        <li><a href="http://migre.me/u3NPW">migre.me => nexojornal.com.br - Por que o uso de canudos está se tornando um problema global</a></li>
+        <li><a href="http://ow.ly/nLNZ30h8PHp">ow.ly => CNN - 'Gods in Color' returns antiquities to their original, colorful grandeur</a></li>
+        <li><a href="http://p.ly/1me3v">p.ly => CBC Radio - Podcast</a></li>
         <li><a href="https://slnk.me/ygQtml-Xsog">Youtube - Feel it in my bones => https://www.youtube.com/watch?v=ygQtml-Xsog)</a></li>
         <li><a href="https://to.ly/1v4Si">Github - URL Revealer</a></li>
         <li><a href="https://tcrn.ch/2LN5kDX">Techcrunch - How Instagram’s algorithm works</a></li>
+        <li><a href="http://tighturl.com/59ln">tighturl.com => Nature.com - A network-based gene-weighting approach for pathway analysis</a></li>
         <li><a href="http://tiny.cc/428cvy">tiny.cc => Google Maps - Mua Cave</a></li>
         <li><a href="https://tinyurl.com/KindleWireless">tinyurl.com => Amazon</a></li>
         <li><a href="http://tny.im/eQ7">tny.im => Google Maps - Mua Cave</a></li>
         <li><a href="https://u.nu/dqt8">u.nu => Github - mdn/webextensions-examples</a></li>
         <li><a href="http://url.ie/12v3z">u.nu => Github - mdn/webextensions-examples</a></li>
         <li><a href="https://urlcut.com/1rrko">urlcut.com => dailymail.co.uk - Alert over energy drinks...</a></li>
+        <li><a href="http://xrl.us/osewb">xrl.us.com => Boston.com - Boston.com - Singapore Grand Prix</a></li>
         <li><a href="http://y2u.be/vyUnzfMh-zA">y2u.be => Youtube - The journey to Pluto, the farthest world ever explored - Alan Stern</a></li>
         <li><a href="http://yatuc.com/yp">yatuc.com => ghacks.net - 5 Best Freeware Games of 2005</a></li>
         <li><a href="http://yep.it/nhpuoh">yep.it => Github - mdn/webextensions-examples</a></li>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -5,10 +5,30 @@
     <meta charset="utf-8" />
     <style>
         body {
-            background: lightblue;
+            background: #fafafa;
         }
         a {
             text-decoration: none;
+            color: #2e5dc5;
+        }
+        table {
+            border-collapse: collapse;
+            border: none;
+            margin: 15px 0;
+        }
+        table thead td {
+            font-weight: bold;
+            color: #565656;
+            background-color: #e8e8e8;
+        }
+        table td {
+            padding: 15px 10px;
+        }
+        table tbody tr:nth-child(2n+1) td {
+            background-color: #f8f8f8;
+        }
+        table tbody tr:nth-child(2n) {
+            background-color: #ffffff;
         }
         .disclaimer {
             padding: 10px 30px;
@@ -41,44 +61,197 @@
         </p>
     </section>
     <h3>Shortened URLs from supported domains</h3>
-    <ul>
-        <li><a href="http://2tu.us/1ua7">2tu.us => offensive-security.com - Penetration Testing...</a></li>
-        <li><a href="http://7.ly/tWxp">7.ly => Google Maps - Mua Cave</a></li>
-        <li><a href="http://alturl.com/a4kcn">alturl.com => Google Maps - Mua Cave</a></li>
-        <li><a href="http://b.link/examples79">b.link => Github - mdn/webextensions-examples</a></li>
-        <li><a href="http://bit.ly/2xxeDVD">bit.ly => Github - URL Revealer</a></li>
-        <li><a href="http://budurl.com/np4u">budurl.com => Flickr - Atlanta Skyline by Mark Chandler</a></li>
-        <li><a href="http://chilp.it/057752b">chilp.it => Github - URL Revealer</a></li>
-        <li><a href="https://doiop.com/jjkwdq">doiop.com => Amazon - The Greatest Baseball Stories Ever Told...</a></li>
-        <li><a href="http://examples.news/github8">examples.news => Github - mdn/webextensions-examples</a></li>
-        <li><a href="http://examples.social/github4">examples.social => Github - mdn/webextensions-examples</a></li>
-        <li><a href="http://fat.ly/2Ohky">fat.ly => denverite.com - Minimum progress for students with...</a></li>
-        <li><a href="http://ff.im/plfSc">ff.im => Facebook - Portadown Liverpool Football Supporters Club</a></li>
-        <li><a href="http://flic.kr/p/26CgBgH">flic.kr => Flickr</a></li>
-        <li><a href="https://git.io/fNYfv">git.io => Github - mdn/webextensions-examples</a></li>
-        <li><a href="http://goo.gl/vGWaZV">goo.gl => Github - URL Revealer</a></li>
-        <li><a href="http://information.codes/example4">information.codes => Github - mdn/webextensions-examples</a></li>
-        <li><a href="https://is.gd/kVx6hw">is.gd => Google Maps - Mua Cave</a></li>
-        <li><a href="http://korta.nu/nsh">korta.nu => strikingly.com - Lighting Shop In Singapore</a></li>
-        <li><a href="http://merky.de/h112f7">merky.de => Github - URL Revealer</a></li>
-        <li><a href="http://migre.me/u3NPW">migre.me => nexojornal.com.br - Por que o uso de canudos está se tornando um problema global</a></li>
-        <li><a href="http://ow.ly/nLNZ30h8PHp">ow.ly => CNN - 'Gods in Color' returns antiquities to their original, colorful grandeur</a></li>
-        <li><a href="http://p.ly/1me3v">p.ly => CBC Radio - Podcast</a></li>
-        <li><a href="https://slnk.me/ygQtml-Xsog">Youtube - Feel it in my bones => https://www.youtube.com/watch?v=ygQtml-Xsog)</a></li>
-        <li><a href="https://tcrn.ch/2LN5kDX">Techcrunch - How Instagram’s algorithm works</a></li>
-        <li><a href="https://to.ly/1v4Si">Github - URL Revealer</a></li>
-        <li><a href="http://tighturl.com/59ln">tighturl.com => Nature.com - A network-based gene-weighting approach for pathway analysis</a></li>
-        <li><a href="http://tiny.cc/428cvy">tiny.cc => Google Maps - Mua Cave</a></li>
-        <li><a href="https://tinyurl.com/KindleWireless">tinyurl.com => Amazon</a></li>
-        <li><a href="http://tny.im/eQ7">tny.im => Google Maps - Mua Cave</a></li>
-        <li><a href="https://u.nu/dqt8">u.nu => Github - mdn/webextensions-examples</a></li>
-        <li><a href="http://url.ie/12v3z">u.nu => Github - mdn/webextensions-examples</a></li>
-        <li><a href="https://urlcut.com/1rrko">urlcut.com => dailymail.co.uk - Alert over energy drinks...</a></li>
-        <li><a href="http://xrl.us/osewb">xrl.us.com => Boston.com - Boston.com - Singapore Grand Prix</a></li>
-        <li><a href="http://y2u.be/vyUnzfMh-zA">y2u.be => Youtube - The journey to Pluto, the farthest world ever explored - Alan Stern</a></li>
-        <li><a href="http://yatuc.com/yp">yatuc.com => ghacks.net - 5 Best Freeware Games of 2005</a></li>
-        <li><a href="http://yep.it/nhpuoh">yep.it => Github - mdn/webextensions-examples</a></li>
-    </ul>
+    <table>
+        <thead>
+            <tr>
+                <td>Service name</td>
+                <td>Shortened URL</td>
+                <td>Original URL</td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><a href="http://2tu.us/">2tu.us</a></td>
+                <td><a href="http://2tu.us/1ua7">http://2tu.us/1ua7</a></td>
+                <td>offensive-security.com - Penetration Testing...</td>
+            </tr>
+            <tr>
+                <td><a href="http://7.ly/">7.ly</a></td>
+                <td><a href="http://7.ly/tWxp">http://7.ly/tWxp</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="http://alturl.com/">alturl.com</a></td>
+                <td><a href="http://alturl.com/a4kcn">http://alturl.com/a4kcn</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="http://b.link/">b.link</a></td>
+                <td><a href="http://b.link/examples79">http://b.link/examples79</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="http://bit.ly/">bit.ly</a></td>
+                <td><a href="http://bit.ly/2xxeDVD">http://bit.ly/2xxeDVD</a></td>
+                <td>Github - URL Revealer</td>
+            </tr>
+            <tr>
+                <td><a href="http://budurl.com/">budurl.com</a></td>
+                <td><a href="http://budurl.com/np4u">http://budurl.com/np4u</a></td>
+                <td>Flickr - Atlanta Skyline by Mark Chandler</td>
+            </tr>
+            <tr>
+                <td><a href="http://chilp.it/">chilp.it</a></td>
+                <td><a href="http://chilp.it/057752b">http://chilp.it/057752b</a></td>
+                <td>Github - URL Revealer</td>
+            </tr>
+            <tr>
+                <td><a href="https://doiop.com/">doiop.com</a></td>
+                <td><a href="https://doiop.com/jjkwdq">https://doiop.com/jjkwdq</a></td>
+                <td>Amazon - The Greatest Baseball Stories Ever Told...</td>
+            </tr>
+            <tr>
+                <td><a href="http://examples.news/">examples.news</a></td>
+                <td><a href="http://examples.news/github8">http://examples.news/github8</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="http://examples.social/">examples.social</a></td>
+                <td><a href="http://examples.social/github4">http://examples.social/github4</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="http://fat.ly/">fat.ly</a></td>
+                <td><a href="http://fat.ly/2Ohky">http://fat.ly/2Ohky</a></td>
+                <td>denverite.com - Minimum progress for students with...</td>
+            </tr>
+            <tr>
+                <td><a href="http://ff.im/">ff.im</a></td>
+                <td><a href="http://ff.im/plfSc">http://ff.im/plfSc</a></td>
+                <td>Facebook - Portadown Liverpool Football Supporters Club</td>
+            </tr>
+            <tr>
+                <td><a href="http://flic.kr/">flic.kr</a></td>
+                <td><a href="http://flic.kr/p/26CgBgH">http://flic.kr/p/26CgBgH</a></td>
+                <td>Flickr - Storm inside by Nguyencanhtung</td>
+            </tr>
+            <tr>
+                <td><a href="https://git.io/">git.io</a></td>
+                <td><a href="https://git.io/fNYfv">https://git.io/fNYfv</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="http://goo.gl/">goo.gl</a></td>
+                <td><a href="http://goo.gl/vGWaZV">http://goo.gl/vGWaZV</a></td>
+                <td>Github - URL Revealer</td>
+            </tr>
+            <tr>
+                <td><a href="http://information.codes/">information.codes</a></td>
+                <td><a href="http://information.codes/example4">http://information.codes/example4</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="https://is.gd/">is.gd</a></td>
+                <td><a href="https://is.gd/kVx6hw">https://is.gd/kVx6hw</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="http://korta.nu/">korta.nu</a></td>
+                <td><a href="http://korta.nu/nsh">http://korta.nu/nsh</a></td>
+                <td>strikingly.com - Lighting Shop In Singapore</td>
+            </tr>
+            <tr>
+                <td><a href="http://merky.de/">merky.de</a></td>
+                <td><a href="http://merky.de/h112f7">http://merky.de/h112f7</a></td>
+                <td>Github - URL Revealer</td>
+            </tr>
+            <tr>
+                <td><a href="http://migre.me/">migre.me</a></td>
+                <td><a href="http://migre.me/u3NPW">http://migre.me/u3NPW</a></td>
+                <td>nexojornal.com.br - Por que o uso de canudos está se tornando um problema global</td>
+            </tr>
+            <tr>
+                <td><a href="http://ow.ly/">ow.ly</a></td>
+                <td><a href="http://ow.ly/nLNZ30h8PHp">http://ow.ly/nLNZ30h8PHp</a></td>
+                <td>CNN - 'Gods in Color' returns antiquities to their original, colorful grandeur</td>
+            </tr>
+            <tr>
+                <td><a href="http://p.ly/">p.ly</a></td>
+                <td><a href="http://p.ly/1me3v">http://p.ly/1me3v</a></td>
+                <td>CBC Radio - Podcast</td>
+            </tr>
+            <tr>
+                <td><a href="https://slnk.me/">slnk.me</a></td>
+                <td><a href="https://slnk.me/ygQtml-Xsog">https://slnk.me/ygQtml-Xsog</a></td>
+                <td>Youtube - Feel it in my bones</td>
+            </tr>
+            <tr>
+                <td><a href="https://tcrn.ch/">tcrn.ch</a></td>
+                <td><a href="https://tcrn.ch/2LN5kDX">https://tcrn.ch/2LN5kDX</a></td>
+                <td>Techcrunch - How Instagram’s algorithm works</td>
+            </tr>
+            <tr>
+                <td><a href="https://to.ly/">to.ly</a></td>
+                <td><a href="https://to.ly/1v4Si">https://to.ly/1v4Si</a></td>
+                <td>Github - URL Revealer</td>
+            </tr>
+            <tr>
+                <td><a href="http://tighturl.com/">tighturl.com</a></td>
+                <td><a href="http://tighturl.com/59ln">http://tighturl.com/59ln</a></td>
+                <td>Nature.com - A network-based gene-weighting approach for pathway analysis</td>
+            </tr>
+            <tr>
+                <td><a href="http://tiny.cc/">tiny.cc</a></td>
+                <td><a href="http://tiny.cc/428cvy">http://tiny.cc/428cvy</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="https://tinyurl.com/">tinyurl.com</a></td>
+                <td><a href="https://tinyurl.com/KindleWireless">https://tinyurl.com/KindleWireless</a></td>
+                <td>Amazon</td>
+            </tr>
+            <tr>
+                <td><a href="http://tny.im/">tny.im</a></td>
+                <td><a href="http://tny.im/eQ7">http://tny.im/eQ7</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="https://u.nu/">u.nu</a></td>
+                <td><a href="https://u.nu/dqt8">https://u.nu/dqt8</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+            <tr>
+                <td><a href="http://url.ie/">url.ie</a></td>
+                <td><a href="http://url.ie/12v3z">http://url.ie/12v3z</a></td>
+                <td>Google Maps - Mua Cave</td>
+            </tr>
+            <tr>
+                <td><a href="https://urlcut.com/">urlcut.com</a></td>
+                <td><a href="https://urlcut.com/1rrko">https://urlcut.com/1rrko</a></td>
+                <td>dailymail.co.uk - Alert over energy drinks...</td>
+            </tr>
+            <tr>
+                <td><a href="http://xrl.us/">xrl.us</a></td>
+                <td><a href="http://xrl.us/osewb">http://xrl.us/osewb</a></td>
+                <td>Boston.com - Boston.com - Singapore Grand Prix</td>
+            </tr>
+            <tr>
+                <td><a href="http://y2u.be/">y2u.be</a></td>
+                <td><a href="http://y2u.be/vyUnzfMh-zA">http://y2u.be/vyUnzfMh-zA</a></td>
+                <td>Youtube - The journey to Pluto, the farthest world ever explored - Alan Stern</td>
+            </tr>
+            <tr>
+                <td><a href="http://yatuc.com/">yatuc.com</a></td>
+                <td><a href="http://yatuc.com/yp">http://yatuc.com/yp</a></td>
+                <td>ghacks.net - 5 Best Freeware Games of 2005</td>
+            </tr>
+            <tr>
+                <td><a href="http://yep.it/">yep.it</a></td>
+                <td><a href="http://yep.it/nhpuoh">http://yep.it/nhpuoh</a></td>
+                <td>Github - mdn/webextensions-examples</td>
+            </tr>
+        </tbody>
+    </table>
 </body>
 
 </html>


### PR DESCRIPTION
- Add disclaimer for demonstration page.
- Update layout of demonstration page.
- Add more supported domains (**21** new domains) and sample URLs for them.

    - 2tu.us
    - budurl.com
    - chilp.it
    - doiop.com
    - fat.ly
    - ff.im
    - korta.nu
    - merky.de
    - migre.me
    - ow.ly
    - p.ly
    - slnk.me
    - tcrn.ch
    - tighturl.com
    - to.ly
    - u.nu
    - url.ie
    - urlcut.com
    - xrl.us
    - yatuc.com
    - yep.it