### PR TITLE
fix(popup): use callback instead of Promise 🐛

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,13 +1,18 @@
 /**
- * There was an error executing the script.
+ * Callback after executing injected script
  */
-function reportExecuteScriptError(error) {
-    console.error(`Failed to execute main content script: ${error.message}`);
+function executeScriptCallback() {
+    if (chrome.runtime.lastError) {
+        console.error(
+            `Failed to execute main content script: ${chrome.runtime.lastError}`
+        );
+    }
 }
 
 /**
  * When the popup loads, inject a content script into the active tab.
- * If we couldn't inject the script, handle the error.
  */
-chrome.tabs.executeScript({ file: "/content_scripts/popup-content-script.js" })
-    .catch(reportExecuteScriptError);
+chrome.tabs.executeScript(
+    { file: '/content_scripts/popup-content-script1.js' },
+    executeScriptCallback
+);


### PR DESCRIPTION
`chrome.tabs.executeScript` uses callback instead of Promise as in `browser.tabs.executeScript`