### PR TITLE
fix(content): error when nodeType !== Node.ELEMENT_NODE 🐛

### DIFF
--- a/content_scripts/main-content-script.js
+++ b/content_scripts/main-content-script.js
@@ -176,7 +176,11 @@ function observeMutation(observedTarget) {
                                 return Array.from(node.querySelectorAll('a'));
                             }
                         } else {
-                            return node.nodeName.toLowerCase() === 'a' ? [node] : Array.from(node.querySelectorAll('a'));
+                            if (node.nodeType === Node.ELEMENT_NODE) {
+                                return node.nodeName.toLowerCase() === 'a' ? [node] : Array.from(node.querySelectorAll('a'));
+                            } else {
+                                return null;
+                            }
                         }
                     }
                 ).filter(node => !!node && node.length);


### PR DESCRIPTION
Ignore nodes which are comment, text, etc.